### PR TITLE
Add command to make centrifugo executable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN addgroup -S centrifugo && adduser -S -G centrifugo centrifugo \
 
 ADD centrifugo /usr/bin/centrifugo
 
+RUN chmod +x /usr/bin/centrifugo
+
 VOLUME ["/centrifugo", "/var/log/centrifugo"]
 
 WORKDIR /centrifugo


### PR DESCRIPTION
If it's not executble on host machine it won't be executable inside docker image.